### PR TITLE
Fix documentation typo and add YAML headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ INVENTARIO-IA/
 │  └─ bash/
 │     └─ up.sh                    # Arranque en bash (opcional)
 ├─ docs/
-│  └─ HAC S-instalacion.md        # Guía rápida de HACS y Grocy
+│  └─ HACS-instalacion.md        # Guía rápida de HACS y Grocy
 ├─ .env                           # TZ/PUID/PGID para Docker
 ├─ docker-compose.yml             # Servicios: Home Assistant + Grocy
 ├─ .gitignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 services:
   homeassistant:
     container_name: homeassistant

--- a/homeassistant/config/configuration.yaml
+++ b/homeassistant/config/configuration.yaml
@@ -1,3 +1,4 @@
+---
 default_config:
 
 homeassistant:

--- a/homeassistant/config/secrets.yaml
+++ b/homeassistant/config/secrets.yaml
@@ -1,2 +1,3 @@
+---
 # NO compartas este archivo en repos públicos si contiene datos reales.
 grocy_api_key: "REEMPLAZA_CON_TU_API_KEY"


### PR DESCRIPTION
## Summary
- fix README path typo for HACS guide
- add missing YAML document start markers to configuration files

## Testing
- `fdupes -r .`
- `shellcheck scripts/bash/up.sh`
- `yamllint homeassistant/config/configuration.yaml docker-compose.yml homeassistant/config/secrets.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68c1a687b4cc8325840949f5b16fb31d