### PR TITLE
Add Grocy Lovelace dashboard configuration and scripts

### DIFF
--- a/grocy-dashboard.yaml
+++ b/grocy-dashboard.yaml
@@ -1,0 +1,79 @@
+title: Grocy Dashboard
+views:
+  - title: Estado
+    path: estado
+    cards:
+      - type: entities
+        entities:
+          - binary_sensor.grocy_products_expired
+          - binary_sensor.grocy_products_expiring
+          - binary_sensor.grocy_products_missing
+          - binary_sensor.grocy_tasks_overdue
+          - binary_sensor.grocy_chores_overdue
+      - type: grid
+        title: Acciones rápidas
+        columns: 2
+        square: false
+        cards:
+          - type: button
+            name: Añadir faltantes a la lista
+            tap_action:
+              action: call-service
+              service: grocy.add_missing_products_to_shopping_list
+          - type: button
+            name: Ejecutar chore
+            tap_action:
+              action: call-service
+              service: grocy.execute_chore
+              service_data:
+                chore_id: "<CHORES_ID>"
+          - type: button
+            name: Consumir producto
+            tap_action:
+              action: call-service
+              service: grocy.consume_product_from_stock
+              service_data:
+                product_id: "<PRODUCT_ID>"
+                amount: "<AMOUNT>"
+          - type: button
+            name: Añadir producto
+            tap_action:
+              action: call-service
+              service: grocy.add_product_to_stock
+              service_data:
+                product_id: "<PRODUCT_ID>"
+                amount: "<AMOUNT>"
+  - title: Tareas y chores
+    path: tareas
+    cards:
+      - type: entities
+        entities:
+          - sensor.grocy_tasks
+          - sensor.grocy_chores
+          - binary_sensor.grocy_tasks_overdue
+          - binary_sensor.grocy_chores_overdue
+      - type: custom:grocy-chores-card
+        show_days: 0
+        show_track_button: true
+        show_create_task: true
+  - title: Compras
+    path: compras
+    cards:
+      - type: entities
+        entities:
+          - binary_sensor.grocy_products_missing
+          - sensor.grocy_shopping_list
+      - type: button
+        name: Abrir Grocy
+        icon: mdi:open-in-new
+        tap_action:
+          action: url
+          url_path: "<GROCY_URL>"
+  - title: Stock
+    path: stock
+    cards:
+      - type: entities
+        entities:
+          - binary_sensor.grocy_products_expired
+          - binary_sensor.grocy_products_expiring
+          - binary_sensor.grocy_products_missing

--- a/grocy-helpers-cards.yaml
+++ b/grocy-helpers-cards.yaml
@@ -1,0 +1,30 @@
+- type: entities
+  entities:
+    - input_text.grocy_product_id
+    - input_number.grocy_amount
+- type: entities
+  entities:
+    - input_text.grocy_chore_id
+- type: button
+  name: Añadir a stock
+  tap_action:
+    action: call-service
+    service: script.grocy_add_to_stock
+    service_data:
+      product_id: "{{ states('input_text.grocy_product_id') | int }}"
+      amount: "{{ states('input_number.grocy_amount') | float }}"
+- type: button
+  name: Consumir de stock
+  tap_action:
+    action: call-service
+    service: script.grocy_consume_from_stock
+    service_data:
+      product_id: "{{ states('input_text.grocy_product_id') | int }}"
+      amount: "{{ states('input_number.grocy_amount') | float }}"
+- type: button
+  name: Ejecutar chore
+  tap_action:
+    action: call-service
+    service: script.grocy_execute_chore
+    service_data:
+      chore_id: "{{ states('input_text.grocy_chore_id') | int }}"

--- a/homeassistant/config/configuration.yaml
+++ b/homeassistant/config/configuration.yaml
@@ -12,3 +12,18 @@ grocy:
   url: "http://grocy:9283"
   api_key: !secret grocy_api_key
   verify_ssl: false
+
+input_number:
+  grocy_amount:
+    name: Grocy amount
+    min: 1
+    max: 20
+    step: 1
+
+input_text:
+  grocy_product_id:
+    name: Grocy product ID
+    max: 6
+  grocy_chore_id:
+    name: Grocy chore ID
+    max: 6

--- a/homeassistant/config/scripts.yaml
+++ b/homeassistant/config/scripts.yaml
@@ -1,0 +1,49 @@
+grocy_add_to_stock:
+  alias: Grocy add to stock
+  fields:
+    product_id:
+      description: ID del producto
+      example: 1
+      required: true
+    amount:
+      description: Cantidad a añadir
+      default: 1
+  sequence:
+    - service: grocy.add_product_to_stock
+      target: {}
+      data:
+        product_id: "{{ product_id }}"
+        amount: "{{ amount }}"
+  mode: single
+
+grocy_consume_from_stock:
+  alias: Grocy consume from stock
+  fields:
+    product_id:
+      description: ID del producto
+      example: 1
+      required: true
+    amount:
+      description: Cantidad a consumir
+      default: 1
+  sequence:
+    - service: grocy.consume_product_from_stock
+      target: {}
+      data:
+        product_id: "{{ product_id }}"
+        amount: "{{ amount }}"
+  mode: single
+
+grocy_execute_chore:
+  alias: Grocy execute chore
+  fields:
+    chore_id:
+      description: ID del chore
+      example: 1
+      required: true
+  sequence:
+    - service: grocy.execute_chore
+      target: {}
+      data:
+        chore_id: "{{ chore_id }}"
+  mode: single


### PR DESCRIPTION
## Summary
- add Lovelace dashboard for Grocy with views for status, chores, shopping, and stock
- add Home Assistant scripts to add or consume products and execute chores via Grocy
- add helpers and sample Lovelace cards to trigger Grocy scripts with user-provided IDs and amounts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1b3ed7abc8325a41145343cf1eae0