### PR TITLE
Add Grocy helper scripts and chores card

### DIFF
--- a/grocy-dashboard.yaml
+++ b/grocy-dashboard.yaml
@@ -53,9 +53,14 @@ views:
           - binary_sensor.grocy_tasks_overdue
           - binary_sensor.grocy_chores_overdue
       - type: custom:grocy-chores-card
+        title: Pendientes
+        entities:
+          - sensor.grocy_chores
+          - sensor.grocy_tasks
         show_days: 0
         show_track_button: true
         show_create_task: true
+        use_24_hours: true
   - title: Compras
     path: compras
     cards:

--- a/homeassistant/config/scripts.yaml
+++ b/homeassistant/config/scripts.yaml
@@ -47,3 +47,32 @@ grocy_execute_chore:
       data:
         chore_id: "{{ chore_id }}"
   mode: single
+
+grocy_add_from_helpers:
+  variables:
+    product_id: "{{ states('input_text.grocy_product_id') | int }}"
+    amount: "{{ states('input_number.grocy_amount') | float }}"
+  sequence:
+    - service: grocy.add_product_to_stock
+      data:
+        product_id: "{{ product_id }}"
+        amount: "{{ amount }}"
+
+grocy_consume_from_helpers:
+  variables:
+    product_id: "{{ states('input_text.grocy_product_id') | int }}"
+    amount: "{{ states('input_number.grocy_amount') | float }}"
+  sequence:
+    - service: grocy.consume_product_from_stock
+      data:
+        product_id: "{{ product_id }}"
+        amount: "{{ amount }}"
+
+grocy_execute_chore_from_helpers:
+  variables:
+    chore_id: "{{ states('input_text.grocy_chore_id') | int }}"
+  sequence:
+    - service: grocy.execute_chore
+      data:
+        chore_id: "{{ chore_id }}"
+


### PR DESCRIPTION
## Summary
- Add scripts to bridge Grocy helpers to stock and chore services
- Show pending chores and tasks via `custom:grocy-chores-card`

## Testing
- `/usr/bin/yamllint homeassistant/config/scripts.yaml grocy-dashboard.yaml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b8d2ef40832584272fff269b9cc3