### PR TITLE
Add Grocy helper scripts and chores card

### DIFF
--- a/grocy-dashboard.yaml
+++ b/grocy-dashboard.yaml
@@ -1,3 +1,4 @@
+---
 title: Grocy Dashboard
 views:
   - title: Estado
@@ -53,9 +54,14 @@ views:
           - binary_sensor.grocy_tasks_overdue
           - binary_sensor.grocy_chores_overdue
       - type: custom:grocy-chores-card
+        title: Pendientes
+        entities:
+          - sensor.grocy_chores
+          - sensor.grocy_tasks
         show_days: 0
         show_track_button: true
         show_create_task: true
+        use_24_hours: true
   - title: Compras
     path: compras
     cards:
@@ -77,3 +83,37 @@ views:
           - binary_sensor.grocy_products_expired
           - binary_sensor.grocy_products_expiring
           - binary_sensor.grocy_products_missing
+  - title: Control rápido
+    path: control-rapido
+    cards:
+      - type: entities
+        entities:
+          - input_text.grocy_product_id
+          - input_number.grocy_amount
+          - input_text.grocy_chore_id
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: button
+            name: Añadir producto
+            tap_action:
+              action: call-service
+              service: script.grocy_add_from_helpers
+          - type: button
+            name: Consumir producto
+            tap_action:
+              action: call-service
+              service: script.grocy_consume_from_helpers
+          - type: button
+            name: Ejecutar chore
+            tap_action:
+              action: call-service
+              service: script.grocy_execute_chore_from_helpers
+      - type: entities
+        entities:
+          - binary_sensor.grocy_products_expired
+          - binary_sensor.grocy_products_expiring
+          - binary_sensor.grocy_products_missing
+          - binary_sensor.grocy_tasks_overdue
+          - binary_sensor.grocy_chores_overdue

--- a/homeassistant/config/automations.yaml
+++ b/homeassistant/config/automations.yaml
@@ -1,3 +1,4 @@
+---
 - id: "a5b6b05f-4806-4ec9-b4f3-eccdc50c9c6c"
   alias: "Añadir productos faltantes a la lista"
   trigger:
@@ -5,3 +6,29 @@
       at: "20:00:00"
   action:
     - service: grocy.add_missing_products_to_shopping_list
+
+- id: "14573ab0-0261-44d0-95af-516ef7b0fef4"
+  alias: "Notificar productos caducados"
+  trigger:
+    - platform: state
+      entity_id: binary_sensor.grocy_products_expired
+      to: "on"
+      for: "00:05:00"
+  action:
+    - service: persistent_notification.create
+      data:
+        title: "Productos caducados"
+        message: "Hay productos caducados en Grocy. Revisa el stock."
+
+- id: "258c4017-22ed-4226-9b8f-18e7507ede42"
+  alias: "Notificar productos faltantes"
+  trigger:
+    - platform: state
+      entity_id: binary_sensor.grocy_products_missing
+      to: "on"
+      for: "00:05:00"
+  action:
+    - service: persistent_notification.create
+      data:
+        title: "Faltan productos"
+        message: "Hay productos faltantes (lista de la compra) en Grocy."

--- a/homeassistant/config/scripts.yaml
+++ b/homeassistant/config/scripts.yaml
@@ -1,3 +1,4 @@
+---
 grocy_add_to_stock:
   alias: Grocy add to stock
   fields:
@@ -47,3 +48,31 @@ grocy_execute_chore:
       data:
         chore_id: "{{ chore_id }}"
   mode: single
+
+grocy_add_from_helpers:
+  variables:
+    product_id: "{{ states('input_text.grocy_product_id') | int }}"
+    amount: "{{ states('input_number.grocy_amount') | float }}"
+  sequence:
+    - service: grocy.add_product_to_stock
+      data:
+        product_id: "{{ product_id }}"
+        amount: "{{ amount }}"
+
+grocy_consume_from_helpers:
+  variables:
+    product_id: "{{ states('input_text.grocy_product_id') | int }}"
+    amount: "{{ states('input_number.grocy_amount') | float }}"
+  sequence:
+    - service: grocy.consume_product_from_stock
+      data:
+        product_id: "{{ product_id }}"
+        amount: "{{ amount }}"
+
+grocy_execute_chore_from_helpers:
+  variables:
+    chore_id: "{{ states('input_text.grocy_chore_id') | int }}"
+  sequence:
+    - service: grocy.execute_chore
+      data:
+        chore_id: "{{ chore_id }}"


### PR DESCRIPTION
## Summary
- Add scripts to bridge Grocy helpers to stock and chore services
- Show pending chores and tasks via `custom:grocy-chores-card`
- Provide "Control rápido" view for quick Grocy actions and status
- Notify when Grocy products are expired or missing

## Testing
- `yamllint homeassistant/config/scripts.yaml grocy-dashboard.yaml homeassistant/config/automations.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68c1b8d2ef40832584272fff269b9cc3