### PR TITLE
Add Barcode Buddy service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,22 @@ services:
     networks:
       - ha_net
 
+  barcodebuddy:
+    container_name: barcodebuddy
+    image: f0rc3/barcodebuddy-docker:latest
+    environment:
+      - OVERRIDDEN_USER_CONFIG="GROCY_API_URL=<http://grocy:9283/api/>;GROCY_API_KEY=<PEGA_TU_API_KEY>"
+    volumes:
+      - bb_config:/config
+    ports:
+      - "9284:80"
+    restart: unless-stopped
+    networks:
+      - ha_net
+
 networks:
   ha_net:
     driver: bridge
+
+volumes:
+  bb_config:


### PR DESCRIPTION
## Summary
- add Barcode Buddy container for Grocy integration

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c867f94883259dec6a556eba9d2e